### PR TITLE
fix(release): run commit-and-tag-version locally to fix bump on main

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -37,7 +37,7 @@
         "BUMPFILE": "dist/version.txt",
         "RELEASETAG": "dist/releasetag.txt",
         "RELEASE_TAG_PREFIX": "",
-        "BUMP_PACKAGE": "commit-and-tag-version@^12"
+        "BUMP_PACKAGE": ""
       },
       "steps": [
         {
@@ -273,7 +273,7 @@
         "BUMPFILE": "dist/version.txt",
         "RELEASETAG": "dist/releasetag.txt",
         "RELEASE_TAG_PREFIX": "",
-        "BUMP_PACKAGE": "commit-and-tag-version@^12"
+        "BUMP_PACKAGE": ""
       },
       "steps": [
         {

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -75,6 +75,16 @@ project.testTask.updateStep(0, {
 // the "devEngines" field that projen also emits.
 const packageJson = project.tryFindObjectFile("package.json");
 packageJson?.addDeletionOverride("packageManager");
+
+// projen 0.100.x invokes commit-and-tag-version via `npx commit-and-tag-version@^12`
+// (through dax), which fails on the GitHub release runner with exit code 127. When
+// BUMP_PACKAGE is empty, projen instead resolves the locally-installed CLI and runs
+// it via node directly (shell-free), which works reliably under pnpm. The package
+// stays a devDependency, so the local resolution always succeeds.
+for (const taskName of ["bump", "unbump"]) {
+  project.tasks.tryFind(taskName)?.env("BUMP_PACKAGE", "");
+}
+
 project.package.addEngine("node", nodeVersion);
 new TextFile(project, ".nvmrc", {
   lines: [workflowNodeVersion],


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## What

Follow-up to #3. The `release` workflow on `main` failed at the `release » bump` step:

```
👾 Number of commits since v0.0.1: 3
Error: Command failed (exit code 127): npx commit-and-tag-version@^12
```

## Why

projen 0.100.x (which `main` adopted in #3) invokes `commit-and-tag-version` through `dax` as `npx commit-and-tag-version@^12`. That npx invocation fails on the GitHub release runner with exit code 127.

projen only takes the `npx` path when the `BUMP_PACKAGE` env var is set (it always is by default). When `BUMP_PACKAGE` is empty, projen instead resolves the locally-installed CLI (`require.resolve("commit-and-tag-version/bin/cli.js")`) and runs it via `node` directly — shell-free, no npx — which works reliably under pnpm.

## Change

- Override the `bump` and `unbump` task envs to clear `BUMP_PACKAGE` (via `.projenrc.ts`, re-synthed into `.projen/tasks.json`).
- `commit-and-tag-version` remains a `devDependency`, so the local resolution always succeeds.

## Verification

- Confirmed locally that with `BUMP_PACKAGE=""` the `bump` task runs end-to-end via the `node` path (exit 0, no npx, no 127).
- `projen compile` and `projen test` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BY1gtNMBikjreWNcup4TkC)_